### PR TITLE
Try to fix inconsistency in docs

### DIFF
--- a/docs/swat-tutorial.rst
+++ b/docs/swat-tutorial.rst
@@ -109,8 +109,8 @@ are monitoring subprocess2 and subprocess3.
    * Compare FIT201 with well defined thresholds
    * Take a decision
    * Update its status
-   * Ask to PLC3 LIT301's value
-   * Compare LIT301 with well defined thresholds
+   * Ask to PLC3 LIT201's value
+   * Compare LIT201 with well defined thresholds
    * Take a decision
    * Update its status
 


### PR DESCRIPTION
LIT301 does not exist in the context of 'images/swat-tutorial-subprocess.png'. Only LIT101 and LIT201 are referenced in that image. I am not sure if the image is wrong or the text in the .rst file is wrong. if it is the text though then this patch should correct it.