### PR TITLE
Documentation update for Ubuntu16.04

### DIFF
--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -45,6 +45,16 @@ The `Install MiniCPS`_ section provides instructions to install ``minicps``
 for a user or a developer, and it assumes that you *already* have installed
 ``mininet``.
 
+.. UPGRADE TO UBUNTU-16.04 {{{3
+
+Upgrade to Ubuntu-16.04
+-----------------------
+
+Some MiniCPS libraries like cryptography now require Ubuntu16.04. To upgrade do:
+.. code-block:: console
+   sudo apt-get update
+   sudo apt-get dist-upgrade
+   sudo do-release-upgrade
 
 .. INSTALL MINICPS {{{3
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-ubuntu16.04
 nose
 rednose
 cryptography

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+ubuntu16.04
 nose
 rednose
 cryptography


### PR DESCRIPTION
Some MiniCPS libraries like cryptography require Ubuntu16.04. Updated requirements.txt and docs/userguide.rst to add instructions to upgrade to Ubuntu16.04