### PR TITLE
Python3 pandas logging

### DIFF
--- a/examples/swat-s1/physical_process.py
+++ b/examples/swat-s1/physical_process.py
@@ -14,6 +14,7 @@ from utils import PUMP_FLOWRATE_IN, PUMP_FLOWRATE_OUT
 from utils import TANK_HEIGHT, TANK_SECTION, TANK_DIAMETER
 from utils import LIT_101_M, RWT_INIT_LEVEL
 from utils import STATE, PP_PERIOD_SEC, PP_PERIOD_HOURS, PP_SAMPLES
+import pandas as pd
 
 import sys
 import time
@@ -37,6 +38,7 @@ class RawWaterTank(Tank):
         # SPHINX_SWAT_TUTORIAL STATE INIT(
         self.set(MV101, 1)
         self.set(P101, 0)
+        self.set(LIT301, 0.300)
         self.level = self.set(LIT101, 0.800)
         # SPHINX_SWAT_TUTORIAL STATE INIT)
 
@@ -48,6 +50,9 @@ class RawWaterTank(Tank):
     def main_loop(self):
 
         count = 0
+        columns = ['Time', 'MV101', 'P101', 'LIT101', 'LIT301', 'FIT101', 'FIT201']
+        df = pd.DataFrame(columns=columns)
+        timestamp=0
         while(count <= PP_SAMPLES):
 
             new_level = self.level
@@ -60,7 +65,7 @@ class RawWaterTank(Tank):
             if int(mv101) == 1:
                 self.set(FIT101, PUMP_FLOWRATE_IN)
                 inflow = PUMP_FLOWRATE_IN * PP_PERIOD_HOURS
-                # print "DEBUG RawWaterTank inflow: ", inflow
+                # print("DEBUG RawWaterTank inflow: ", inflow)
                 water_volume += inflow
             else:
                 self.set(FIT101, 0.00)
@@ -70,7 +75,7 @@ class RawWaterTank(Tank):
             if int(p101) == 1:
                 self.set(FIT201, PUMP_FLOWRATE_OUT)
                 outflow = PUMP_FLOWRATE_OUT * PP_PERIOD_HOURS
-                # print "DEBUG RawWaterTank outflow: ", outflow
+                # print("DEBUG RawWaterTank outflow: ", outflow)
                 water_volume -= outflow
             else:
                 self.set(FIT201, 0.00)
@@ -83,22 +88,27 @@ class RawWaterTank(Tank):
                 new_level = 0.0
 
             # update internal and state water level
-            print "DEBUG new_level: %.5f \t delta: %.5f" % (
-                new_level, new_level - self.level)
+            print("DEBUG new_level: %.5f \t delta: %.5f" % (
+                new_level, new_level - self.level))
             self.level = self.set(LIT101, new_level)
 
             # 988 sec starting from 0.500 m
             if new_level >= LIT_101_M['HH']:
-                print 'DEBUG RawWaterTank above HH count: ', count
+                print('DEBUG RawWaterTank above HH count: ', count)
                 break
 
             # 367 sec starting from 0.500 m
             elif new_level <= LIT_101_M['LL']:
-                print 'DEBUG RawWaterTank below LL count: ', count
+                print('DEBUG RawWaterTank below LL count: ', count)
                 break
-
+                
+            new_data = pd.DataFrame(data = [[timestamp, self.get(MV101), self.get(P101), self.get(LIT101), self.get(LIT301), self.get(FIT101), self.get(FIT201)]], columns=columns)
+            print(new_data)
+            df = pd.concat([df,new_data])
+            df.to_csv('logs/data.csv', index=False)
             count += 1
             time.sleep(PP_PERIOD_SEC)
+            timestamp+=PP_PERIOD_SEC
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 try:
     from setuptools import setup
 except ImportError:
@@ -7,7 +7,7 @@ except ImportError:
 # NOTE: https://packaging.python.org/
 setup(
     name='minicps',
-    version='1.1.3',
+    version='1.1.4',
     description='MiniCPS: a framework for Cyber-Physical Systems \
 real-time simulation, built on top of mininet.',
     # NOTE: long_description displayed on PyPi
@@ -28,8 +28,8 @@ on top of mininet.',
         'Natural Language :: English',
         'Operating System :: POSIX :: Linux',
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
         'Topic :: Education',
         'Topic :: Scientific/Engineering :: Information Analysis',
         'Topic :: Security',
@@ -43,7 +43,8 @@ on top of mininet.',
         'cryptography',
         'pyasn1',
         'pymodbus',
-        'cpppo',
+        'cpppo==4.3.4',
+        'pandas',
     ],
     # NOTE: specify files relative to the module path
     package_data={},


### PR DESCRIPTION
Added pandas to the `setup.py`, to support the csv logging. Minor changes in `physical_process.py` to the pandas logging feature

Modified the following
1. add pandas in the `setup.py` to support csv logging
2. df.append is deprecated, use pd.concat instead in `examples/swat-s1/physical_process.py` 
3. fixed dumping of LIT301 value in the `examples/swat-s1/logs/data.csv` file