### PR TITLE
Support for multitag requests on ENIP

### DIFF
--- a/minicps/devices.py
+++ b/minicps/devices.py
@@ -254,13 +254,27 @@ class Device(object):
         else:
             return self._protocol._send(what, value, address, **kwargs)
 
+    def send_multiple(self, what, value, address, **kwargs):
+        """Send (write) a list of values to another network host.
+
+        ``kwargs`` dict is used to pass extra key-value pair according to the
+        used protocol.
+
+        :param list what:  fields identifiers
+        :param value: values to be setted
+        :param str address: ``ip[:port]``
+        :returns: ``None`` or ``TypeError`` if ``what`` is not a ``tuple``
+        """
+
+        return self._protocol._send_multiple(what, value, address, **kwargs)
+
     def receive(self, what, address, **kwargs):
         """Receive (read) a value from another network host.
 
         ``kwargs`` dict is used to pass extra key-value pair according to the
         used protocol.
 
-        :param tuple what: field[s] identifier[s]
+        :param list what: field[s] identifier[s]
         :param str address: ``ip[:port]``
 
         :returns: received value or ``TypeError`` if ``what`` is not a ``tuple``
@@ -270,6 +284,19 @@ class Device(object):
             raise TypeError('Parameter must be a tuple.')
         else:
             return self._protocol._receive(what, address, **kwargs)
+
+    def receive_multiple(self, what, address, **kwargs):
+        """Receive (read) a value from another network host.
+
+        ``kwargs`` dict is used to pass extra key-value pair according to the
+        used protocol.
+
+        :param list what: field[s] identifier[s]
+        :param str address: ``ip[:port]``
+        :returns: received value or ``TypeError`` if ``what`` is not a ``tuple``
+        """
+
+        return self._protocol._receive_multiple(what, address, **kwargs)
 
 
 # TODO: rename pre_loop and main_loop?

--- a/minicps/protocols.py
+++ b/minicps/protocols.py
@@ -308,7 +308,7 @@ class EnipProtocol(Protocol):
             tags_string += '='
             tags_string += str(tag[-1])
             tags_string += ' '
-        print('DEBUG enip server tags_string: ', tags_string)
+        # print('DEBUG enip server tags_string: ', tags_string)
 
         return tags_string
 
@@ -520,7 +520,7 @@ class EnipProtocol(Protocol):
 
                 # client.communicate is blocking
                 raw_out = client.communicate()
-                print(f'DEBUG enip _receive_multiple {raw_out}: ', raw_out)
+                # print(f'DEBUG enip _receive_multiple {raw_out}: ', raw_out)
 
                 # value is stored as first tuple element
                 # between a pair of square brackets

--- a/minicps/protocols.py
+++ b/minicps/protocols.py
@@ -464,7 +464,7 @@ class EnipProtocol(Protocol):
         tag_string = ''
         tag_string = EnipProtocol._tuple_to_cpppo_tag(what)
 
-        print("DEBUG " + tag_string)
+        # print("DEBUG " + tag_string)
 
         cmd = shlex.split(
             self._client_cmd +
@@ -480,16 +480,16 @@ class EnipProtocol(Protocol):
 
             # client.communicate is blocking
             raw_out = client.communicate()
-            print('DEBUG1 ', raw_out)
+            # print('DEBUG1 ', raw_out)
 
             # value is stored as first tuple element
             # between a pair of square brackets
 
             raw_string = raw_out[0]
-            print("DEBUG2 " + str(raw_string))
+            # print("DEBUG2 " + str(raw_string))
             raw_string = str(raw_string)
             out = raw_string[(raw_string.find('[') + 1):raw_string.find(']')]
-            print("DEBUG4 " + out)
+            # print("DEBUG4 " + out)
             return out
 
         except Exception as error:

--- a/minicps/protocols.py
+++ b/minicps/protocols.py
@@ -469,7 +469,7 @@ class EnipProtocol(Protocol):
         cmd = shlex.split(
             self._client_cmd +
             '--log ' + self._client_log +
-            '--address ' + address +
+            ' --print --address ' + address +
             ' ' + tag_string
         )
         # print 'DEBUG enip _receive cmd shlex list: ', cmd
@@ -510,7 +510,7 @@ class EnipProtocol(Protocol):
             cmd = shlex.split(
                 self._client_cmd +
                 '--log ' + self._client_log +
-                '--address ' + address +
+                ' --print --address ' + address +
                 ' ' + tag_string
             )
 
@@ -520,7 +520,7 @@ class EnipProtocol(Protocol):
 
                 # client.communicate is blocking
                 raw_out = client.communicate()
-                #print 'DEBUG enip _receive_multiple raw_out: ', raw_out
+                print(f'DEBUG enip _receive_multiple {raw_out}: ', raw_out)
 
                 # value is stored as first tuple element
                 # between a pair of square brackets

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ on top of mininet.',
         'cryptography',
         'pyasn1',
         'pymodbus',
-        'cpppo==4.3.4',
+        'cpppo',
         'pandas',
     ],
     # NOTE: specify files relative to the module path


### PR DESCRIPTION
Two functions are added to devices.py and protocols.py to support sending and receiving multiple tags using ENIP. 