### PR TITLE
setup.py: numpy explicitly added to requirements list with static version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ on top of mininet.',
         'pyasn1',
         'pymodbus',
         'cpppo',
+        'numpy==2.2.6',
         'pandas',
     ],
     # NOTE: specify files relative to the module path


### PR DESCRIPTION
**Problem:**
Installing MiniCPS with `sudo python3 setup.py install` returns the following error message:
`
Searching for numpy>=1.22.4
Reading https://pypi.org/simple/numpy/
Downloading https://files.pythonhosted.org/packages/f3/db/8e12381333aea300890829a0a36bfa738cac95475d88982d538725143fd9/numpy-2.3.0.tar.gz#sha256=581f87f9e9e9db2cba2141400e160e9dd644ee248788d6f90636eeb8fd9260a6
Best match: numpy 2.3.0
Processing numpy-2.3.0.tar.gz
error: Couldn't find a setup script in /tmp/easy_install-t24446ol/numpy-2.3.0.tar.gz
`
It seems that newer numpy versions do not longer provide the required setup script.

**Solution:**
This commit adds numpy as a requirement and forces a specific version which is prior to 2.3.0 (i.e., 2.2.6) to solve the error mentioned above.